### PR TITLE
Add Max-Forwards header to CANCEL and ACK requests

### DIFF
--- a/sip/request.go
+++ b/sip/request.go
@@ -273,6 +273,8 @@ func NewCancelRequest(cancelID MessageID, requestForCancel Request, fields log.F
 
 	viaHop, _ := requestForCancel.ViaHop()
 	cancelReq.AppendHeader(ViaHeader{viaHop.Clone()})
+	maxForwardsHeader := MaxForwards(70)
+	cancelReq.AppendHeader(&maxForwardsHeader)
 	CopyHeaders("Route", requestForCancel, cancelReq)
 	CopyHeaders("From", requestForCancel, cancelReq)
 	CopyHeaders("To", requestForCancel, cancelReq)

--- a/sip/request.go
+++ b/sip/request.go
@@ -227,6 +227,9 @@ func NewAckRequest(ackID MessageID, inviteRequest Request, inviteResponse Respon
 			}),
 	)
 
+	maxForwardsHeader := MaxForwards(70)
+	ackRequest.AppendHeader(&maxForwardsHeader)
+
 	CopyHeaders("Via", inviteRequest, ackRequest)
 	viaHop, _ := ackRequest.ViaHop()
 	// update branch, 2xx ACK is separate Tx

--- a/transaction/client_tx.go
+++ b/transaction/client_tx.go
@@ -266,6 +266,9 @@ func (tx *clientTx) ack() {
 	cseq.MethodName = sip.ACK
 	ack.AppendHeader(cseq)
 
+	maxForwardsHeader := sip.MaxForwards(70)
+	ack.AppendHeader(&maxForwardsHeader)
+
 	// Send the ACK.
 	err := tx.tpl.Send(ack)
 	if err != nil {


### PR DESCRIPTION
Canceling an invite request with `clientTransaction.Cancel()` and the ACK sent
automatically to a INVITE response lack a Max-Forwards header. This means some
clients (eg. Linphone) won't accept the request (in fact Linphone rejects the
ACK with a 400, causing a loop of 400 / ACKs between gosip and linphone).

This adds the header to these requests.

There may be a better place to do this that would prevent the same problem
on other requests: happy to update this PR or for you to fix it in a different
way if you'd prefer.

Thanks!