### PR TITLE
Added missing MESSAGE type

### DIFF
--- a/sip/message.go
+++ b/sip/message.go
@@ -42,6 +42,7 @@ const (
 	NOTIFY    RequestMethod = "NOTIFY"
 	REFER     RequestMethod = "REFER"
 	INFO      RequestMethod = "INFO"
+	MESSAGE   RequestMethod = "MESSAGE"
 )
 
 type MessageID string


### PR DESCRIPTION
The `MESSAGE` request type is pretty widespread these days. See [RFC 3428](https://tools.ietf.org/html/rfc3428) (2002).