### PR TITLE
Fix panic when header key is empty

### DIFF
--- a/sip/headers.go
+++ b/sip/headers.go
@@ -194,7 +194,7 @@ func (params *headerParams) ToString(sep uint8) string {
 
 		if val, ok := val.(String); ok {
 			valStr := val.String()
-			if valStr[0] == '"' && valStr[len(valStr)-1] == '"' { // already escaped header param value
+			if valStr != "" && valStr[0] == '"' && valStr[len(valStr)-1] == '"' { // already escaped header param value
 				buffer.WriteString(fmt.Sprintf("=%s", valStr))
 			} else if strings.ContainsAny(valStr, abnfWs) {
 				buffer.WriteString(fmt.Sprintf("=\"%s\"", strings.ReplaceAll(Escape(valStr, EncodeQueryComponent), "\"", "\\\"")))


### PR DESCRIPTION
I meet panic when sent Request with empty "rport" param in ia header.

The panic is as below:
```
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 12 [running]:
testing.tRunner.func1.2({0x1607fc0, 0xc00002f4e8})
	/Users/go/go1.19/src/testing/testing.go:1396 +0x24e
testing.tRunner.func1()
	/Users/go/go1.19/src/testing/testing.go:1399 +0x39f
panic({0x1607fc0, 0xc00002f4e8})
	/Users/go/go1.19/src/runtime/panic.go:884 +0x212
github.com/ghettovoice/gosip/sip.(*headerParams).ToString(0xc00007fb40, 0x3b)
	/Users/code/gosip/sip/headers.go:197 +0x438
github.com/ghettovoice/gosip/sip.(*ViaHop).String(0xc000038d80)
	/Users/code/gosip/sip/headers.go:1141 +0x1e2
github.com/ghettovoice/gosip/sip.ViaHeader.Value({0xc000014100, 0x1, 0x10f62be?})
	/Users/code/gosip/sip/headers.go:1060 +0x5d
github.com/ghettovoice/gosip/sip.ViaHeader.String({0xc000014100?, 0xc000143340?, 0xc000032dc0?})
	/Users/code/gosip/sip/headers.go:1052 +0x25
github.com/ghettovoice/gosip/sip.(*headers).String(0xc00007fac0)
	/Users/code/gosip/sip/message.go:148 +0x15e
```

I fond the problem is when the code run to `sip.(*headerParams).ToString()`, if the header param key is empty, then `valStr` will be empy, so `valStr[0]` out of range.
