### PR TITLE
fix parse module panic if given uri is sip or sips only

### DIFF
--- a/sip/parser/parser.go
+++ b/sip/parser/parser.go
@@ -657,13 +657,21 @@ func ParseSipUri(uriStr string) (uri sip.SipUri, err error) {
 		return
 	}
 	uriStr = uriStr[3:]
-
+	// check if URI authority part exist after scheme
+	if len(uriStr) < 1 {
+		err = fmt.Errorf("uri too short to parse. '%s'", uriStrCopy)
+		return
+	}
 	if strings.ToLower(uriStr[0:1]) == "s" {
 		// URI started 'sips', so it's encrypted.
 		uri.FIsEncrypted = true
 		uriStr = uriStr[1:]
 	}
-
+	// check if URI authority part exist after scheme
+	if len(uriStr) < 1 {
+		err = fmt.Errorf("uri too short to parse. '%s'", uriStrCopy)
+		return
+	}
 	// The 'sip' or 'sips' protocol name should be followed by a ':' character.
 	if uriStr[0] != ':' {
 		err = fmt.Errorf("no ':' after protocol name in SIP uri '%s'", uriStrCopy)

--- a/sip/parser/parser_test.go
+++ b/sip/parser/parser_test.go
@@ -287,6 +287,8 @@ func TestSipUris(t *testing.T) {
 		{sipUriInput("sip:bob@example.com:5;foo=baz?foo"), &sipUriResult{fail, sip.SipUri{}}},
 		{sipUriInput("sip:bob@example.com:50;foo=baz?foo"), &sipUriResult{fail, sip.SipUri{}}},
 		{sipUriInput("sip:bob@example.com:50;foo=baz?foo=bar&baz"), &sipUriResult{fail, sip.SipUri{}}},
+		{sipUriInput("sip"), &sipUriResult{fail, sip.SipUri{}}},
+		{sipUriInput("sips"), &sipUriResult{fail, sip.SipUri{}}},
 	}, t)
 }
 


### PR DESCRIPTION
If the SIP uri is provided as **sip** or **sips** only , the parse module goes in to panic mode because uri index goes out of range once the protocol idenfier (scheme part) gets stripped from the URI.


`panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/ghettovoice/gosip/sip/parser.ParseSipUri(0xc0000166a8, 0x4, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        D:/wsl/golang/pkg/mod/github.com/ghettovoice/gosip@v0.0.0-20221107092729-1af110a09790/sip/parser/parser.go:668 +0xc29
`

I have added a condition to check if URI authority portion length is > 0 before accessing the URI substring.


