### PR TITLE
Refactor[log]: Increase portability/compatibility of log interface

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -34,10 +34,10 @@ type Logger interface {
 	WithPrefix(prefix string) Logger
 	Prefix() string
 
-	WithFields(fields Fields) Logger
+	WithFields(fields map[string]interface{}) Logger
 	Fields() Fields
 
-	SetLevel(level Level)
+	SetLevel(level uint32)
 }
 
 type Loggable interface {

--- a/log/logrus.go
+++ b/log/logrus.go
@@ -120,14 +120,14 @@ func (l *LogrusLogger) Panicf(format string, args ...interface{}) {
 }
 
 func (l *LogrusLogger) WithPrefix(prefix string) Logger {
-	return NewLogrusLogger(l.log, prefix, l.Fields())
+	return NewLogrusLogger(l.log, prefix, map[string]interface{}(l.Fields()))
 }
 
 func (l *LogrusLogger) Prefix() string {
 	return l.prefix
 }
 
-func (l *LogrusLogger) WithFields(fields Fields) Logger {
+func (l *LogrusLogger) WithFields(fields map[string]interface{}) Logger {
 	return NewLogrusLogger(l.log, l.Prefix(), l.Fields().WithFields(fields))
 }
 
@@ -141,7 +141,7 @@ func (l *LogrusLogger) prepareEntry() *logrus.Entry {
 		WithField("prefix", l.Prefix())
 }
 
-func (l *LogrusLogger) SetLevel(level Level) {
+func (l *LogrusLogger) SetLevel(level uint32) {
 	if ll, ok := l.log.(*logrus.Logger); ok {
 		ll.SetLevel(logrus.Level(level))
 	}


### PR DESCRIPTION
The types `Level` and `Fields` being required in the methods of the interface thrashes the portability of the interface. If the interface requires a `gosip/log.Level` (a uint32), then I can't implement the interface without importing the package. This fixes this by changing the interface requirements to be the generic underlying types, and casting them when necessary within the logrus implementation.