### PR TITLE
Fix addr-spec parsing following RFC 8217

### DIFF
--- a/sip/header/contact_test.go
+++ b/sip/header/contact_test.go
@@ -17,6 +17,31 @@ var _ = Describe("Header", Label("sip", "header"), func() {
 			Entry(nil, "Contact:", &header.Any{Name: "Contact"}, nil),
 			Entry(nil, "Contact: *", header.Contact{}, nil),
 			Entry(nil,
+				"Contact: sips:alice@127.0.0.1;tag=a48s",
+				header.Contact{{
+					URI:    &uri.SIP{User: uri.User("alice"), Addr: uri.Host("127.0.0.1"), Secured: true},
+					Params: make(header.Values).Set("tag", "a48s"),
+				}},
+				nil,
+			),
+			Entry(nil,
+				"Contact: https://example.org/username?tag=a48s",
+				header.Contact{{
+					URI:    &uri.Any{Scheme: "https", Host: "example.org", Path: "/username"},
+					Params: make(header.Values).Set("tag", "a48s"),
+				}},
+				nil,
+			),
+			Entry(nil,
+				"Contact: \"A. G. Bell\" <sip:agb@bell-telephone.com>\r\n\t;tag=a48s",
+				header.Contact{{
+					DisplayName: "A. G. Bell",
+					URI:         &uri.SIP{User: uri.User("agb"), Addr: uri.Host("bell-telephone.com")},
+					Params:      make(header.Values).Set("tag", "a48s"),
+				}},
+				nil,
+			),
+			Entry(nil,
 				"Contact: \"Mr. Watson\" <sip:watson@worcester.bell-telephone.com>\r\n"+
 					"\t;q=0.7; expires=3600,\r\n"+
 					"\t\"Mr. Watson\" <mailto:watson@bell-telephone.com> ;q=0.1",

--- a/sip/header/from_test.go
+++ b/sip/header/from_test.go
@@ -16,6 +16,30 @@ var _ = Describe("Header", Label("sip", "header"), func() {
 			// region
 			Entry(nil, "From: ", &header.Any{Name: "From"}, nil),
 			Entry(nil,
+				"From: sip:alice@127.0.0.1;tag=a48s",
+				&header.From{
+					URI:    &uri.SIP{User: uri.User("alice"), Addr: uri.Host("127.0.0.1")},
+					Params: make(header.Values).Set("tag", "a48s"),
+				},
+				nil,
+			),
+			Entry(nil,
+				"From: sips:alice@127.0.0.1;tag=a48s",
+				&header.From{
+					URI:    &uri.SIP{User: uri.User("alice"), Addr: uri.Host("127.0.0.1"), Secured: true},
+					Params: make(header.Values).Set("tag", "a48s"),
+				},
+				nil,
+			),
+			Entry(nil,
+				"From: https://example.org/username?tag=a48s",
+				&header.From{
+					URI:    &uri.Any{Scheme: "https", Host: "example.org", Path: "/username"},
+					Params: make(header.Values).Set("tag", "a48s"),
+				},
+				nil,
+			),
+			Entry(nil,
 				"From: \"A. G. Bell\" <sip:agb@bell-telephone.com>\r\n\t;tag=a48s",
 				&header.From{
 					DisplayName: "A. G. Bell",

--- a/sip/header/reply_to_test.go
+++ b/sip/header/reply_to_test.go
@@ -16,6 +16,30 @@ var _ = Describe("Header", Label("sip", "header"), func() {
 			// region
 			Entry(nil, "Reply-To: ", &header.Any{Name: "Reply-To"}, nil),
 			Entry(nil,
+				"Reply-To: sip:alice@127.0.0.1;tag=a48s",
+				&header.ReplyTo{
+					URI:    &uri.SIP{User: uri.User("alice"), Addr: uri.Host("127.0.0.1")},
+					Params: make(header.Values).Set("tag", "a48s"),
+				},
+				nil,
+			),
+			Entry(nil,
+				"Reply-To: sips:alice@127.0.0.1;tag=a48s",
+				&header.ReplyTo{
+					URI:    &uri.SIP{User: uri.User("alice"), Addr: uri.Host("127.0.0.1"), Secured: true},
+					Params: make(header.Values).Set("tag", "a48s"),
+				},
+				nil,
+			),
+			Entry(nil,
+				"Reply-To: https://example.org/username?tag=a48s",
+				&header.ReplyTo{
+					URI:    &uri.Any{Scheme: "https", Host: "example.org", Path: "/username"},
+					Params: make(header.Values).Set("tag", "a48s"),
+				},
+				nil,
+			),
+			Entry(nil,
 				"Reply-To: \"A. G. Bell\" <sip:agb@bell-telephone.com>\r\n\t;tag=a48s",
 				&header.ReplyTo{
 					DisplayName: "A. G. Bell",

--- a/sip/header/to_test.go
+++ b/sip/header/to_test.go
@@ -14,8 +14,8 @@ var _ = Describe("Header", Label("sip", "header"), func() {
 	Describe("To", func() {
 		assertHeaderParsing(
 			// region
-			PEntry(nil, "To: ", &header.Any{Name: "To"}, nil),
-			Entry("ambiguous sip header RFC 8217",
+			Entry(nil, "To: ", &header.Any{Name: "To"}, nil),
+			Entry(nil,
 				"To: sip:alice@127.0.0.1;tag=a48s",
 				&header.To{
 					URI:    &uri.SIP{User: uri.User("alice"), Addr: uri.Host("127.0.0.1")},
@@ -23,7 +23,7 @@ var _ = Describe("Header", Label("sip", "header"), func() {
 				},
 				nil,
 			),
-			Entry("ambiguous sips header RFC 8217",
+			Entry(nil,
 				"To: sips:alice@127.0.0.1;tag=a48s",
 				&header.To{
 					URI:    &uri.SIP{User: uri.User("alice"), Addr: uri.Host("127.0.0.1"), Secured: true},
@@ -31,7 +31,7 @@ var _ = Describe("Header", Label("sip", "header"), func() {
 				},
 				nil,
 			),
-			Entry("ambiguous header RFC 8217",
+			Entry(nil,
 				"To: https://example.org/username?tag=a48s",
 				&header.To{
 					URI:    &uri.Any{Scheme: "https", Host: "example.org", Path: "/username"},

--- a/sip/header/to_test.go
+++ b/sip/header/to_test.go
@@ -14,7 +14,31 @@ var _ = Describe("Header", Label("sip", "header"), func() {
 	Describe("To", func() {
 		assertHeaderParsing(
 			// region
-			Entry(nil, "To: ", &header.Any{Name: "To"}, nil),
+			PEntry(nil, "To: ", &header.Any{Name: "To"}, nil),
+			Entry("ambiguous sip header RFC 8217",
+				"To: sip:alice@127.0.0.1;tag=a48s",
+				&header.To{
+					URI:    &uri.SIP{User: uri.User("alice"), Addr: uri.Host("127.0.0.1")},
+					Params: make(header.Values).Set("tag", "a48s"),
+				},
+				nil,
+			),
+			Entry("ambiguous sips header RFC 8217",
+				"To: sips:alice@127.0.0.1;tag=a48s",
+				&header.To{
+					URI:    &uri.SIP{User: uri.User("alice"), Addr: uri.Host("127.0.0.1"), Secured: true},
+					Params: make(header.Values).Set("tag", "a48s"),
+				},
+				nil,
+			),
+			Entry("ambiguous header RFC 8217",
+				"To: https://example.org/username?tag=a48s",
+				&header.To{
+					URI:    &uri.Any{Scheme: "https", Host: "example.org", Path: "/username"},
+					Params: make(header.Values).Set("tag", "a48s"),
+				},
+				nil,
+			),
 			Entry(nil,
 				"To: \"A. G. Bell\" <sip:agb@bell-telephone.com>\r\n\t;tag=a48s",
 				&header.To{


### PR DESCRIPTION
A quick fix that addresses the RFC 8217. 
I'll add tests for the other headers it impacts later.