### PR TITLE
Add Element receive request/response test

### DIFF
--- a/sip/element_test.go
+++ b/sip/element_test.go
@@ -4,153 +4,177 @@ import (
 	"context"
 	"net"
 	"net/netip"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/ghettovoice/gosip/log"
 	"github.com/ghettovoice/gosip/sip"
 	"github.com/ghettovoice/gosip/sip/header"
 	"github.com/ghettovoice/gosip/uri"
 )
 
-func TestElement(t *testing.T) {
-	tp, err := sip.NewConnlessTransport(
-		sip.UDPTransportMetadata(),
-		&sip.ConnlessTransportOptions{
-			TransportOptions: sip.TransportOptions{
-				Logger: log.Console(),
-			},
-		},
-	)
+func TestElement_ReceiveRequestResponse(t *testing.T) {
+	t.Parallel()
+
+	lis, err := net.ListenPacket("udp", "127.0.0.1:0")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("net.ListenPacket(listener) error = %v, want nil", err)
 	}
 
-	rmtConn, err := net.ListenPacket("udp", "127.0.0.1:5070")
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Cleanup(func() { lis.Close() })
 
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		log.Console().Info("starting listener...")
+	lisAddr := netip.MustParseAddrPort(lis.LocalAddr().String())
 
-		err := tp.ListenAndServe(t.Context(), "127.0.0.1:5060")
-
-		log.Console().Info("listener stopped", "error", err)
+	tp, err := sip.NewConnlessTransport(sip.UDPTransportMetadata(), &sip.ConnlessTransportOptions{
+		TransportOptions: sip.TransportOptions{SentBy: sip.AddrFromHostPort("127.0.0.1", lisAddr.Port())},
 	})
-	wg.Go(func() {
-		log.Console().Info("starting remote conn reader...")
-
-		buf := make([]byte, sip.MaxMessageSize)
-		for {
-			n, addr, err := rmtConn.ReadFrom(buf)
-			if err != nil {
-				log.Console().Info("remote conn reader stopped", "error", err)
-				return
-			}
-
-			log.Console().Info("received message", "addr", addr, "message", string(buf[:n]))
-		}
-	})
-
-	elm, err := sip.NewElement(
-		"QwertY",
-		tp,
-		&sip.ElementOptions{
-			TransactionOptions: &sip.TransactionManagerOptions{},
-			Logger:             log.Console(),
-		},
-	)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("sip.NewConnlessTransport() error = %v, want nil", err)
 	}
+
+	elm, err := sip.NewElement("TestElement", tp, &sip.ElementOptions{TransactionOptions: &sip.TransactionManagerOptions{}})
+	if err != nil {
+		t.Fatalf("sip.NewElement() error = %v, want nil", err)
+	}
+
+	t.Cleanup(func() { elm.Close() })
+
+	peer, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.ListenPacket(peer) error = %v, want nil", err)
+	}
+
+	t.Cleanup(func() { peer.Close() })
+
+	peerAddr := netip.MustParseAddrPort(peer.LocalAddr().String())
+	reqCh := make(chan *sip.InboundRequestEnvelope, 1)
+	resCh := make(chan *sip.InboundResponseEnvelope, 1)
 
 	elm.TransportManager().UseInterceptor(sip.StdMessageInterceptor{
-		InboundRequest: sip.InboundRequestInterceptorFunc(func(ctx context.Context, req *sip.InboundRequestEnvelope, next sip.RequestReceiver) error {
-			log.Console().Info("intercepted request")
-			return nil
-		}),
+		InboundRequest: sip.InboundRequestInterceptorFunc(
+			func(ctx context.Context, req *sip.InboundRequestEnvelope, next sip.RequestReceiver) error {
+				reqCh <- req
+				return nil
+			},
+		),
+		InboundResponse: sip.InboundResponseInterceptorFunc(
+			func(ctx context.Context, res *sip.InboundResponseEnvelope, next sip.ResponseReceiver) error {
+				resCh <- res
+				return nil
+			},
+		),
 	})
 
-	time.Sleep(time.Second)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
 
-	if _, err := rmtConn.WriteTo(
-		[]byte(
-			"INVITE sip:bob@b.example.com SIP/2.0\r\n"+
-				"Via: SIP/2.0/UDP a.example.com;branch=qwerty,\r\n"+
-				"\tSIP/2.0/UDP b.example.com;branch=asdf\r\n"+
-				"Via: SIP/2.0/UDP c.example.com;branch=zxcvb\r\n"+
-				"From: <sip:alice@a.example.com>;tag=abc\r\n"+
-				"To: sip:bob@b.example.com\r\n"+
-				"CSeq: 1 INVITE\r\n"+
-				"Call-ID: zxc\r\n"+
-				"Max-Forwards: 70\r\n"+
-				"Contact: <sip:alice@a.example.com:5060>;transport=tcp\r\n"+
-				"X-Generic-Header: 123\r\n"+
-				"Content-Type: text/plain\r\n"+
-				"Content-Length: 14\r\n"+
-				"P-Custom-Header: 123 abc\r\n"+
-				"\r\n"+
-				"Hello world!\r\n",
-		),
-		&net.UDPAddr{
-			IP:   net.ParseIP("127.0.0.1"),
-			Port: 5060,
-		},
-	); err != nil {
-		t.Fatal(err)
+	done := make(chan error, 1)
+	go func() { done <- tp.ServeListener(ctx, lis) }()
+
+	t.Cleanup(func() {
+		cancel()
+		lis.Close()
+		<-done
+	})
+
+	if _, err := peer.WriteTo([]byte(newElementTestRequest(t, lisAddr).Render(nil)), net.UDPAddrFromAddrPort(lisAddr)); err != nil {
+		t.Fatalf("peer.WriteTo(request) error = %v, want nil", err)
 	}
 
-	time.Sleep(time.Second)
+	var gotReq *sip.InboundRequestEnvelope
+	select {
+	case gotReq = <-reqCh:
+	case <-time.After(asyncEventTimeout):
+		t.Fatalf("inbound request not received")
+	}
 
-	req, err := sip.NewOutboundRequestEnvelope(
-		&sip.Request{
-			Proto:  sip.ProtoVer20(),
-			Method: sip.RequestMethodInfo,
-			URI: &uri.SIP{
-				User: uri.User("test"),
-				Addr: uri.AddrFromHostPort("127.0.0.1", 5070),
-			},
-			Headers: make(sip.Headers).
-				Set(
-					&header.From{
-						URI: &uri.SIP{
-							User: uri.User("alice"),
-							Addr: uri.AddrFromHost("a.example.com"),
-						},
-						Params: make(header.Values).Append("tag", "abc"),
-					},
-					&header.To{
-						URI: &uri.SIP{
-							User: uri.User("bob"),
-							Addr: uri.AddrFromHost("b.example.com"),
-						},
-					},
-				).
-				Set(
-					&header.CSeq{SeqNum: 1, Method: "INVITE"},
-					header.CallID("zxc"),
-					header.MaxForwards(70),
-				),
-		},
+	if gotReq == nil || gotReq.Message() == nil {
+		t.Fatalf("inbound request = nil, want non-nil")
+	}
+
+	if got := gotReq.Method(); got != sip.RequestMethodInvite {
+		t.Fatalf("inbound request method = %v, want %v", got, sip.RequestMethodInvite)
+	}
+
+	if got := gotReq.Transport(); got != sip.TransportProto("UDP") {
+		t.Fatalf("inbound request transport = %v, want UDP", got)
+	}
+
+	if got := gotReq.LocalAddr(); got != lisAddr {
+		t.Fatalf("inbound request local addr = %v, want %v", got, lisAddr)
+	}
+
+	if got := gotReq.RemoteAddr(); got != peerAddr {
+		t.Fatalf("inbound request remote addr = %v, want %v", got, peerAddr)
+	}
+
+	if _, err := peer.WriteTo([]byte(newElementTestResponse(t, lisAddr).Render(nil)), net.UDPAddrFromAddrPort(lisAddr)); err != nil {
+		t.Fatalf("peer.WriteTo(response) error = %v, want nil", err)
+	}
+
+	var gotRes *sip.InboundResponseEnvelope
+	select {
+	case gotRes = <-resCh:
+	case <-time.After(asyncEventTimeout):
+		t.Fatalf("inbound response not received")
+	}
+
+	if gotRes == nil || gotRes.Message() == nil {
+		t.Fatalf("inbound response = nil, want non-nil")
+	}
+
+	if got := gotRes.Message().Status; got != sip.ResponseStatusOK {
+		t.Fatalf("inbound response status = %v, want %v", got, sip.ResponseStatusOK)
+	}
+
+	if got := gotRes.Transport(); got != sip.TransportProto("UDP") {
+		t.Fatalf("inbound response transport = %v, want UDP", got)
+	}
+
+	if got := gotRes.LocalAddr(); got != lisAddr {
+		t.Fatalf("inbound response local addr = %v, want %v", got, lisAddr)
+	}
+
+	if got := gotRes.RemoteAddr(); got != peerAddr {
+		t.Fatalf("inbound response remote addr = %v, want %v", got, peerAddr)
+	}
+}
+
+func newElementTestRequest(tb testing.TB, laddr netip.AddrPort) *sip.Request {
+	tb.Helper()
+
+	req, err := sip.NewRequest(
+		sip.RequestMethodInvite,
+		&uri.SIP{User: uri.User("bob"), Addr: uri.AddrFromHost("example.com")},
+		&uri.SIP{User: uri.User("alice"), Addr: uri.AddrFromHost("example.com")},
+		&uri.SIP{User: uri.User("bob"), Addr: uri.AddrFromHost("example.com")},
+		&sip.RequestOptions{Transport: "UDP", Branch: sip.GenerateBranch(0), LocalTag: "from-tag", CallID: "call-id"},
 	)
 	if err != nil {
-		t.Logf("%+v", err)
+		tb.Fatalf("sip.NewRequest() error = %v, want nil", err)
 	}
 
-	req.SetRemoteAddr(netip.MustParseAddrPort("127.0.0.1:5070"))
+	req.Headers.Set(header.Via{{
+		Proto:     sip.ProtoVer20(),
+		Transport: "UDP",
+		Addr:      header.AddrFromHostPort(laddr.Addr().String(), laddr.Port()),
+		Params:    make(header.Values).Set("branch", sip.GenerateBranch(0)),
+	}})
+	req.Headers.Set(header.ContentLength(0))
 
-	if err := elm.SendRequest(t.Context(), req, &sip.SendRequestOptions{RenderCompact: true}); err != nil {
-		t.Logf("%+v", err)
+	return req
+}
+
+func newElementTestResponse(tb testing.TB, laddr netip.AddrPort) *sip.Response {
+	tb.Helper()
+
+	req := newElementTestRequest(tb, laddr)
+
+	res, err := req.NewResponse(sip.ResponseStatusOK, &sip.ResponseOptions{LocalTag: "to-tag"})
+	if err != nil {
+		tb.Fatalf("req.NewResponse() error = %v, want nil", err)
 	}
 
-	time.Sleep(time.Second)
+	res.Headers.Set(header.ContentLength(0))
 
-	rmtConn.Close()
-
-	if err := elm.Close(); err != nil {
-		t.Logf("%+v", err)
-	}
+	return res
 }


### PR DESCRIPTION
## Summary
- Replaced the old ad-hoc `TestElement` with a deterministic UDP-based test for receiving both SIP requests and responses via `sip.Element`.
- Added helpers to build valid minimal SIP request/response messages and assert inbound envelope method/status, transport, local address, and remote address.

## Review & Testing Checklist for Human
- [ ] Check that the receive flow assertions cover the intended `sip.Element` behavior.
- [ ] Run `go test -race -vet=all -timeout=30s ./...` locally if you want to verify against your Go/toolchain setup.

### Notes
- Local verification passed: `go test ./sip`, `go test -race -vet=all -timeout=30s ./...`, and `golangci-lint run ./...`.

Link to Devin session: https://app.devin.ai/sessions/a17976b6381c4bee85350cf1bb052493
Requested by: @ghettovoice